### PR TITLE
fix: validate project titles and path safety (closes #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,14 @@ SSD_UUID=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX ./newvlog.sh
 - 既存を使うか、新規プロジェクトを作るかを選択
 - 新規作成時:
   - タイトル入力（未入力時は `NewProject`）
+  - タイトル許可文字: 英数字 / 日本語（ひらがな・カタカナ・漢字）/ 空白 / `.` / `_` / `-`
+  - 禁止例: `/`, `..`, 先頭 `-`, 制御文字
   - Tier選択
     - `TIER_1__KEEP`
     - `TIER_2__STORE`
     - `TIER_3__TEMP`
   - 既存名と重複時は `-1`, `-2` ... を付けて作成
+  - 作成先は必ず選択した Tier 配下になるよう検証
   - `_Template` があれば内容をコピー
   - `_Assets` があれば `Assets` シンボリックリンクを作成
 

--- a/newvlog.sh
+++ b/newvlog.sh
@@ -179,6 +179,39 @@ select_tier() {
     echo "${TIER_FOLDERS[$tier_choice]}"
 }
 
+is_valid_project_title() {
+    local title="$1"
+
+    [[ -z "$title" ]] && return 1
+    [[ "$title" == -* ]] && return 1
+    [[ "$title" == *"/"* ]] && return 1
+    [[ "$title" == *".."* ]] && return 1
+
+    if printf '%s' "$title" | LC_ALL=C grep -q '[[:cntrl:]]'; then
+        return 1
+    fi
+
+    if ! printf '%s' "$title" | grep -Eq '^[A-Za-z0-9._ ぁ-んァ-ン一-龥々ー\-]+$'; then
+        return 1
+    fi
+
+    return 0
+}
+
+is_path_within_tier() {
+    local tier_path="$1"
+    local target_path="$2"
+    local tier_real=""
+    local parent_real=""
+    local target_real=""
+
+    tier_real="$(cd "$tier_path" 2>/dev/null && pwd -P)" || return 1
+    parent_real="$(cd "$(dirname "$target_path")" 2>/dev/null && pwd -P)" || return 1
+    target_real="${parent_real}/$(basename "$target_path")"
+
+    [[ "$target_real" == "$tier_real" || "$target_real" == "$tier_real"/* ]]
+}
+
 
 # ==========================================
 # 1. SSD準備 & 履歴ロード
@@ -376,10 +409,6 @@ for DEVICE_ENTRY in $DETECTED_DEVICES; do
         fi
 
         if $IS_NEW_PROJECT; then
-            print -n "  🏷  タイトルを入力: "
-            read USER_TITLE
-            TITLE="${USER_TITLE:-$DEFAULT_TITLE}"
-
             # Select tier for new project
             SELECTED_TIER=$(select_tier)
             TIER_PATH="$FOOTAGE_ROOT/$SELECTED_TIER"
@@ -390,7 +419,24 @@ for DEVICE_ENTRY in $DETECTED_DEVICES; do
                 mkdir -p "$TIER_PATH"
             fi
 
+            while true; do
+                print -n "  🏷  タイトルを入力: "
+                read USER_TITLE
+                TITLE="${USER_TITLE:-$DEFAULT_TITLE}"
+
+                if ! is_valid_project_title "$TITLE"; then
+                    print "  ⚠️  タイトルに使えない文字列です。英数/日本語/空白/._- のみ利用可能です。"
+                    print "      禁止例: '/', '..', 先頭 '-'"
+                    continue
+                fi
+                break
+            done
+
             BASE_DIR="${TIER_PATH}/${TARGET_DATE}-${TITLE}"
+            if ! is_path_within_tier "$TIER_PATH" "$BASE_DIR"; then
+                print "❌ 作成先パスがTier配下に収まりません: $BASE_DIR"
+                exit 1
+            fi
             TARGET_PROJECT_DIR="$BASE_DIR"
 
             count=1
@@ -398,6 +444,11 @@ for DEVICE_ENTRY in $DETECTED_DEVICES; do
                 TARGET_PROJECT_DIR="${BASE_DIR}-${count}"
                 count=$((count + 1))
             done
+
+            if ! is_path_within_tier "$TIER_PATH" "$TARGET_PROJECT_DIR"; then
+                print "❌ 最終作成先パスがTier配下に収まりません: $TARGET_PROJECT_DIR"
+                exit 1
+            fi
 
             mkdir -p "$TARGET_PROJECT_DIR"
             [[ -d "$TEMPLATE_DIR" ]] && cp -R "$TEMPLATE_DIR"/. "$TARGET_PROJECT_DIR"


### PR DESCRIPTION
## Summary
- add strict project title validation for new project creation
- allow only ASCII/Japanese text plus space, dot, underscore, hyphen
- reject dangerous inputs such as `/`, `..`, leading `-`, and control chars
- verify final project path always stays inside the selected tier
- document the title rules in README

## Testing
- `zsh -n newvlog.sh`
- function-level checks for valid/invalid titles
- path containment checks for inside/outside tier paths

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * プロジェクトタイトルの入力検証が強化されました。英数字、日本語文字、スペース、ドット、アンダースコア、ハイフンが使用可能です
  * プロジェクト作成時の保存先がティアディレクトリ内に配置されていることを確認する検証機能を追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->